### PR TITLE
Investigate serious action issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -36,8 +37,6 @@ jobs:
       
       - name: Setup Pages
         uses: actions/configure-pages@v4
-        with:
-          enablement: true
       
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Resolve GitHub Pages deployment failure by removing `enablement: true` and adding `actions: read` permission.

The `HttpError: Resource not accessible by integration` occurred because `enablement: true` in `actions/configure-pages@v4` attempts to automatically enable GitHub Pages via the API, which the default GitHub Actions token lacks permissions for. Removing this option allows the deployment to proceed after Pages is manually enabled in repository settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-7138e228-d91c-410f-9dad-9befe8487e1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7138e228-d91c-410f-9dad-9befe8487e1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

